### PR TITLE
docs: remove sustainability recommendations from documentation

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -58,8 +58,7 @@ Vibebells is a complete, production-ready handbell arrangement generator availab
 - ✅ **Player expansion**: Automatically adds players when capacity insufficient
 
 ### Quality & Validation
-- ✅ **Quality scoring**: 0-100 score based on distribution, occupancy, utilization, melody coverage, hand swap efficiency
-- ✅ **Sustainability analysis**: Bell spacing and reachability recommendations
+- ✅ **Quality scoring**: 0-100 score based on distribution, occupancy, utilization, melody coverage
 - ✅ **Constraint validation**: Enforces minimum 2 bells, maximum per experience level
 - ✅ **Conflict resolution**: Deduplication and balancing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-A desktop and web application that generates handbell arrangements for songs. Upload a MIDI or MusicXML file, configure players by experience level, and get multiple arrangement strategies with quality scoring and sustainability recommendations.
+A desktop and web application that generates handbell arrangements for songs. Upload a MIDI or MusicXML file, configure players by experience level, and get multiple arrangement strategies with quality scoring.
 
 ## ✨ Features
 
@@ -20,7 +20,6 @@ A desktop and web application that generates handbell arrangements for songs. Up
 - 🎵 **Music Parsing**: Supports MIDI and MusicXML formats
 - 🎯 **Multiple Strategies**: Three arrangement algorithms (experienced-first, balanced, min-transitions)
 - 📊 **Quality Scoring**: 0-100 score based on distribution, occupancy, utilization, and melody coverage
-- 🔍 **Sustainability Analysis**: Bell spacing and reachability recommendations for player comfort
 - ⚖️ **Conflict Resolution**: Automatic deduplication and balancing of arrangements
 - 💎 **Modern UI**: Next.js 15 with App Router and React 19
 - 🔔 **Multi-Bell Support**: Players can manage up to 5 bells with hand assignment optimization
@@ -90,7 +89,6 @@ cd frontend && npm run dev
    - View quality score (0-100)
    - Check bell assignments and hand positions for each player
    - Review swap counts to understand bell transfer frequency
-   - Read sustainability recommendations
    - Compare different strategies
 5. **Export**: Download arrangement as CSV for printing or sharing
 

--- a/backend/app/services/arrangement_validator.py
+++ b/backend/app/services/arrangement_validator.py
@@ -88,11 +88,10 @@ class ArrangementValidator:
     @staticmethod
     def sustainability_check(arrangement, music_data):
         """
-        Check sustainability: ensure players can physically ring bells without fatigue.
+        Check sustainability: ensure arrangement is practical for performance.
         
-        Heuristics:
-        - Players with bells in both hands should have them at different registers (not adjacent)
-        - Melody players should have some lower-register support
+        Returns basic sustainability status. Most physical playability concerns
+        are handled by bell count limits per experience level.
         
         Args:
             arrangement: Dict mapping player names to assignment dicts
@@ -101,49 +100,12 @@ class ArrangementValidator:
         Returns:
             Dict with sustainability metrics
         """
-        from app.services.music_parser import MusicParser
-        
         issues = []
         recommendations = []
         
-        for player_name, player_data in arrangement.items():
-            bells = player_data.get('bells', [])
-            
-            if len(bells) >= 2:
-                # Check pitch distance between bells
-                pitches = []
-                for bell_name in bells:
-                    # Parse bell name (e.g., "C4" -> pitch estimation)
-                    try:
-                        # Rough pitch mapping: C=0, D=2, E=4, F=5, G=7, A=9, B=11
-                        note_letter = bell_name[0]
-                        octave = int(bell_name[1:]) if len(bell_name) > 1 else 4
-                        
-                        note_to_semitone = {'C': 0, 'D': 2, 'E': 4, 'F': 5, 'G': 7, 'A': 9, 'B': 11}
-                        midi_pitch = 12 * (octave + 1) + note_to_semitone.get(note_letter, 0)
-                        pitches.append((bell_name, midi_pitch))
-                    except:
-                        pass
-                
-                # Check spacing between all pairs
-                for i in range(len(pitches)):
-                    for j in range(i + 1, len(pitches)):
-                        bell_name_i, pitch_i = pitches[i]
-                        bell_name_j, pitch_j = pitches[j]
-                        pitch_distance = abs(pitch_j - pitch_i)
-                        
-                        # Warn if bells are too close (less than 3 semitones)
-                        if pitch_distance < 3:
-                            recommendations.append(
-                                f"{player_name}: Bells {bell_name_i} and {bell_name_j} are very close ({pitch_distance} semitones). "
-                                f"Consider spacing further apart for easier ringing."
-                            )
-                        
-                        # Recommend distribution for large ranges
-                        if pitch_distance > 12:
-                            recommendations.append(
-                                f"{player_name}: Large range ({pitch_distance} semitones). Ensure player can comfortably reach all bells."
-                            )
+        # Currently no sustainability issues to check beyond validation constraints
+        # Bell count limits (2/3/5 per experience level) handle capacity concerns
+        # Hand assignments ensure even distribution between hands
         
         return {
             'issues': issues,


### PR DESCRIPTION
Removed references to sustainability analysis and bell spacing recommendations from user-facing documentation. Physical playability is handled by experience- level bell limits (2/3/5 bells max), making pitch distance checks unnecessary.

The sustainability_check() function now returns empty recommendations, which is correct since bell placement in front of players makes pitch spacing irrelevant to physical comfort.